### PR TITLE
Better printing for file install

### DIFF
--- a/src/decman/__init__.py
+++ b/src/decman/__init__.py
@@ -217,10 +217,10 @@ class Directory:
         if group is not None:
             self.gid = grp.getgrnam(group).gr_gid
 
-    def copy_to(
-            self,
-            target_directory: str,
-            variables: typing.Optional[dict[str, str]] = None) -> list[str]:
+    def copy_to(self,
+                target_directory: str,
+                variables: typing.Optional[dict[str, str]] = None,
+                only_print: bool = False) -> list[str]:
         """
         Copies the files in this directory to the target directory.
 
@@ -242,7 +242,9 @@ class Directory:
                     target = os.path.normpath(
                         os.path.join(target_directory, src_path))
                     created.append(target)
-                    file.copy_to(target, variables)
+
+                    if not only_print:
+                        file.copy_to(target, variables)
         finally:
             os.chdir(original_wd)
         return created

--- a/src/decman/app.py
+++ b/src/decman/app.py
@@ -32,11 +32,10 @@ def main():
                         help="python file containing configuration")
     parser.add_argument(
         "--print",
+        "--dry-run",
         action="store_true",
         default=False,
-        help=
-        "print what would happen as a result of running decman (doesn't print removed files)"
-    )
+        help="print what would happen as a result of running decman")
     parser.add_argument("--debug",
                         action="store_true",
                         default=False,
@@ -263,22 +262,17 @@ class Core:
 
     def _create_and_remove_files(self):
         l.print_summary("Installing files.")
-        l.print_list("Files to install:",
-                     self.source.all_file_targets(),
-                     elements_per_line=1,
-                     level=l.INFO)
-        l.print_list("Directories to install:",
-                     self.source.all_directory_targets(),
-                     elements_per_line=1,
-                     level=l.INFO)
+
+        all_created = self.source.create_all_files(self.only_print)
+        to_remove = self.source.files_to_remove(self.store, all_created)
+
+        l.print_list("Ensured files are up to date:",
+                     all_created,
+                     elements_per_line=1)
+        l.print_list("Removing files:", to_remove, elements_per_line=1)
 
         if self.only_print:
             return
-
-        all_created = self.source.create_all_files()
-        to_remove = self.source.files_to_remove(self.store, all_created)
-
-        l.print_list("Removing files:", to_remove, elements_per_line=1)
 
         for file in to_remove:
             try:

--- a/src/decman/lib/__init__.py
+++ b/src/decman/lib/__init__.py
@@ -459,7 +459,7 @@ class Source:
             elif module.enabled and module.name not in store.enabled_modules:
                 module.after_version_change()
 
-    def create_all_files(self) -> list[str]:
+    def create_all_files(self, only_print: bool) -> list[str]:
         """
         Creates all files and returns them. The files created are based on the specified files,
         directories and modules.
@@ -470,9 +470,13 @@ class Source:
                           variables: typing.Optional[dict[str, str]] = None):
             for target, file in files.items():
                 created_files.append(target)
+
+                if only_print:
+                    continue
+
                 try:
-                    file.copy_to(target, variables)
                     print_debug(f"Installing file to {target}.")
+                    file.copy_to(target, variables)
                 except OSError as e:
                     print_error(f"{e}")
                     raise err.UserFacingError(
@@ -483,7 +487,8 @@ class Source:
             for target, directory in dirs.items():
                 try:
                     print_debug(f"Installing directory to {target}.")
-                    created_files.extend(directory.copy_to(target, variables))
+                    created_files.extend(
+                        directory.copy_to(target, variables, only_print))
                 except OSError as e:
                     print_error(f"{e}")
                     raise err.UserFacingError(


### PR DESCRIPTION
- print all managed files including those defined with directories
- CLI option --print now also shows files that would be removed
- added --dry-run alias to --print