### PR TITLE
DRAFT: Add Flatpak support

### DIFF
--- a/src/decman/__init__.py
+++ b/src/decman/__init__.py
@@ -400,4 +400,5 @@ enabled_systemd_units: list[str] = []
 enabled_systemd_user_units: dict[str, list[str]] = {}
 files: dict[str, File] = {}
 directories: dict[str, Directory] = {}
+flatpaks: list[str] = []
 modules: list[Module] = []

--- a/src/decman/config.py
+++ b/src/decman/config.py
@@ -187,6 +187,22 @@ class Commands:
 
         return makechrootpkg_cmd
 
+    def install_flatpak(self, flatpaks: list[str]):
+        """
+        Running this command installs Flatpaks
+        """
+        return [
+            "flatpak",
+            "install",
+            "--system",
+        ] + flatpaks
+
+    def uninstall_flatpak(self, flatpaks: list[str]):
+        """
+        Running this command uninstalls Flatpaks
+        """
+        return ["flatpak", "uninstall", "--system"] + flatpaks
+
 
 commands: Commands = Commands()
 debug_output: bool = False


### PR DESCRIPTION
Add support for managing Flatpaks.

Currently this is a simple add that tracks Flatpaks similarly to how decman tracks systemd units.

I could modify this to behave more similarly to packages, which are uninstalled if not found in the Source. I wanted to get different opinions on this before moving forward.

Personally, I think that decman should be pretty aggressive with maintaining the source file as the source of truth. Perhaps there could be a flag to turn this off?

Resolves #10 