### PR TITLE
Start/stop SystemD services when enabling/disabling

### DIFF
--- a/src/decman/config.py
+++ b/src/decman/config.py
@@ -90,25 +90,25 @@ class Commands:
         """
         Running this command enables the given systemd units.
         """
-        return ["systemctl", "enable"] + units
+        return ["systemctl", "enable", "--now"] + units
 
     def disable_units(self, units: list[str]) -> list[str]:
         """
         Running this command disables the given systemd units.
         """
-        return ["systemctl", "disable"] + units
+        return ["systemctl", "disable", "--now"] + units
 
     def enable_user_units(self, units: list[str], user: str) -> list[str]:
         """
         Running this command enables the given systemd units for the user.
         """
-        return ["systemctl", "--user", "-M", f"{user}@", "enable"] + units
+        return ["systemctl", "--user", "-M", f"{user}@", "enable", "--now"] + units
 
     def disable_user_units(self, units: list[str], user: str) -> list[str]:
         """
         Running this command disables the given systemd units for the user.
         """
-        return ["systemctl", "--user", "-M", f"{user}@", "disable"] + units
+        return ["systemctl", "--user", "-M", f"{user}@", "disable", "--now"] + units
 
     def compare_versions(self, installed_version: str,
                          new_version: str) -> list[str]:


### PR DESCRIPTION
Currently, Decman enabels services but doesn not start them, requiring users to manually start services by running `systemctl start example.service`. This can lead to confusion or extra steps for users expecting services to be active immediately after enabling them

The `--now` flag for `systemctl` starts or stops services immediately when enabling or disabling, so running `systemctl enable --now example.service` is equivalent to `systemctl enable example.service; systemctl start example.service`. The same goes for user services.
