### PR TITLE
Fix bug in module user systemd unit handling

### DIFF
--- a/src/decman/lib/__init__.py
+++ b/src/decman/lib/__init__.py
@@ -680,11 +680,13 @@ class Source:
         return result
 
     def _all_user_units(self) -> dict[str, set[str]]:
-        result = {}
-        result.update(self.systemd_user_units)
-        for module in self.modules:
-            if module.enabled:
-                result.update(module.systemd_user_units())
+        result = self.systemd_user_units
+        for module in [m for m in self.modules if m.enabled]:
+            module_user_units: dict[str, list[str]] = module.systemd_user_units()
+            for user in module_user_units.keys():
+                if user not in result:
+                    result[user] = set()
+                result[user].update(module_user_units[user])
         return result
 
 


### PR DESCRIPTION
Simple fix for a bug I noticed in my own usage.

`update` clobbers the existing set upon key collisions. I have most 'applications' set up as modules, so each one that ran a user unit as my user overwrote the previous set of user units.

This is a draft while I write unit tests for this. I wanted to ask if I could add `pytest` as a dev dependency. I think the suites you have would get more clarity from the `fixture` pattern that pytest provides. If you'd prefer to stick to `stdlib`, that's fine.